### PR TITLE
クレカ登録機能修正

### DIFF
--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -14,8 +14,8 @@ class CardsController < ApplicationController
 
   #payjpとCardのデータベース作成
   def pay
-
-    Payjp.api_key = ENV['PAYJP_SECRET_KEY']
+    Payjp.api_key = 'sk_test_fec9fa1c578abfe4162abfad'
+    # Payjp.api_key = ENV['PAYJP_SECRET_KEY']
     if params['payjp-token'].blank?
       redirect_to action: "new"
     else
@@ -35,7 +35,8 @@ class CardsController < ApplicationController
   def show
     card = Card.where(user_id: current_user.id).first
     if card.present?
-      Payjp.api_key = ENV['PAYJP_SECRET_KEY']
+      Payjp.api_key = 'sk_test_fec9fa1c578abfe4162abfad'
+      # Payjp.api_key = ENV['PAYJP_SECRET_KEY']
       customer = Payjp::Customer.retrieve(card.customer_id)
       @card_information = customer.cards.retrieve(card.card_id)
     else
@@ -47,7 +48,8 @@ class CardsController < ApplicationController
   def delete
     card = Card.where(user_id: current_user.id).first
     if card.present?
-      Payjp.api_key = ENV['PAYJP_SECRET_KEY']
+      Payjp.api_key = 'sk_test_fec9fa1c578abfe4162abfad'
+      # Payjp.api_key = ENV['PAYJP_SECRET_KEY']
       customer = Payjp::Customer.retrieve(card.customer_id)
       customer.delete
       card.delete

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -14,8 +14,7 @@ class CardsController < ApplicationController
 
   #payjpとCardのデータベース作成
   def pay
-    Payjp.api_key = 'sk_test_fec9fa1c578abfe4162abfad'
-    # Payjp.api_key = ENV['PAYJP_SECRET_KEY']
+    Payjp.api_key = ENV['PAYJP_PRIVATE_KEY']
     if params['payjp-token'].blank?
       redirect_to action: "new"
     else
@@ -35,8 +34,7 @@ class CardsController < ApplicationController
   def show
     card = Card.where(user_id: current_user.id).first
     if card.present?
-      Payjp.api_key = 'sk_test_fec9fa1c578abfe4162abfad'
-      # Payjp.api_key = ENV['PAYJP_SECRET_KEY']
+      Payjp.api_key = ENV['PAYJP_PRIVATE_KEY']
       customer = Payjp::Customer.retrieve(card.customer_id)
       @card_information = customer.cards.retrieve(card.card_id)
     else
@@ -48,8 +46,7 @@ class CardsController < ApplicationController
   def delete
     card = Card.where(user_id: current_user.id).first
     if card.present?
-      Payjp.api_key = 'sk_test_fec9fa1c578abfe4162abfad'
-      # Payjp.api_key = ENV['PAYJP_SECRET_KEY']
+      Payjp.api_key = ENV['PAYJP_PRIVATE_KEY']
       customer = Payjp::Customer.retrieve(card.customer_id)
       customer.delete
       card.delete

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -22,7 +22,7 @@ production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   aws_access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
   aws_secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>
-  payjp_secret_key: <%= ENV["PAYJP_SECRET_KEY"] %>
+  payjp_secret_key: <%= ENV["PAYJP_PRIVATE_KEY"] %>
 
 
 


### PR DESCRIPTION
#what
本番環境でクレジットカードを登録できるように修正
#why
本番環境において、クレジットカードを登録しようとするとpayjpとの連携ができていなく、登録ができない。
秘密鍵の設定がローカルとは別方法となるため修正
