### PR TITLE
ログインページのフロントの修正

### DIFF
--- a/app/assets/stylesheets/_cards.scss
+++ b/app/assets/stylesheets/_cards.scss
@@ -1,3 +1,26 @@
+.main-form {
+  margin: 0 auto;
+  width: 700px;
+  background: white;
+  .credit-information {
+    margin: 10px 0;
+    padding: 0 200px;
+  }
+  .btn-wrapper {
+    margin-top: 30px;
+    .delete-btn {
+      border: 1px solid transparent;
+      background-color: #ea352d;
+      color: #fff;
+      line-height: 48px;
+      width: 100%;
+      cursor: pointer;
+      border-radius: 4px;
+    }
+  }
+  
+}
+
 .card-logo {
   display: flex;
   margin-top: 10px;

--- a/app/assets/stylesheets/_user.scss
+++ b/app/assets/stylesheets/_user.scss
@@ -165,15 +165,9 @@ select {
     }
   }
 }
-header {
-  height: 128px;
-}
-footer {
-  height: 220px;
-}
 .signin-form {
   width: 456px;
-  height: 700px;
+  height: 750px;
   background-color: #fff;
   margin: 0 auto;
   &__no-account {

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -14,7 +14,7 @@ class CardsController < ApplicationController
 
   #payjpとCardのデータベース作成
   def pay
-    Payjp.api_key = ENV['SECRET_KEY']
+    Payjp.api_key = ENV['PAYJP_PRIVATE_KEY']
     if params['payjp-token'].blank?
       redirect_to action: "new"
     else
@@ -34,7 +34,7 @@ class CardsController < ApplicationController
   def show
     card = Card.where(user_id: current_user.id).first
     if card.present?
-      Payjp.api_key = ENV['SECRET_KEY']
+      Payjp.api_key = ENV['PAYJP_PRIVATE_KEY']
       customer = Payjp::Customer.retrieve(card.customer_id)
       @card_information = customer.cards.retrieve(card.card_id)
     else
@@ -46,7 +46,7 @@ class CardsController < ApplicationController
   def delete
     card = Card.where(user_id: current_user.id).first
     if card.present?
-      Payjp.api_key = ENV['SECRET_KEY']
+      Payjp.api_key = ENV['PAYJP_PRIVATE_KEY']
       customer = Payjp::Customer.retrieve(card.customer_id)
       customer.delete
       card.delete

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -31,36 +31,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
     if @user.save
       sign_in(:user, @user)
-      redirect_to controller: '/cards', action: 'new'
+      redirect_to new_card_path
     else
       render :new_sending_destination
     end
   end
-
-
-  # GET /resource/edit
-  # def edit
-  #   super
-  # end
-
-  # PUT /resource
-  # def update
-  #   super
-  # end
-
-  # DELETE /resource
-  # def destroy
-  #   super
-  # end
-
-  # GET /resource/cancel
-  # Forces the session data which is usually expired after sign
-  # in to be expired now. This is useful if the user wants to
-  # cancel oauth signing in/up in the middle of the process,
-  # removing all OAuth session data.
-  # def cancel
-  #   super
-  # end
 
   protected
   def configure_sign_up_params
@@ -71,18 +46,4 @@ class Users::RegistrationsController < Devise::RegistrationsController
     params.require(:sending_destination).permit(:destination_family_name, :destination_first_name, :destination_family_name_kana, :destination_first_name_kana, :post_code, :prefecture_id, :city, :house_number, :building_name, :phone_number)
   end
 
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_account_update_params
-  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
-  # end
-
-  # The path used after sign up.
-  # def after_sign_up_path_for(resource)
-  #   super(resource)
-  # end
-
-  # The path used after sign up for inactive accounts.
-  # def after_inactive_sign_up_path_for(resource)
-  #   super(resource)
-  # end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -31,7 +31,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
     if @user.save
       sign_in(:user, @user)
-      redirect_to controller: '/toppage', action: 'index'
+      redirect_to controller: '/cards', action: 'new'
     else
       render :new_sending_destination
     end

--- a/app/views/cards/index.html.haml
+++ b/app/views/cards/index.html.haml
@@ -1,9 +1,9 @@
-.payment-method
-  %h2.payment-method_title
-  お支払方法
-  .payment-method_contents
-  クレジットカード一覧
-  %br
-  = link_to "クレジットカードを追加する", new_card_path
-  %br
-  支払い方法について
+%body
+  = render 'layouts/header_simple'
+  .main-form
+    %h2.main-form__title
+      お支払方法
+    .default-btn
+      = link_to "クレジットカードを追加する", new_card_path
+    %br
+  = render 'layouts/footer_simple'

--- a/app/views/cards/new.html.haml
+++ b/app/views/cards/new.html.haml
@@ -1,71 +1,71 @@
 %body
-  %header
-  %main
-    .main-form
-      = form_tag(pay_cards_path, method: :post, id: 'charge-form',  name: "inputForm") do
-        %h2.main-form__title クレジットカード情報
-        .main-form__wrapper
-          .main-contents
-            .contents-field--first
-              = label_tag "number", "カード番号", class: 'label'
-              %span.contents-field__require 必須
-              = text_field_tag "number", "4242424242424242", class: 'contents-field__input', placeholder: '半角数字のみ', maxlength: "16"
-              %ul.card-logo
-                %li
-                = image_tag "icon/logo_visa.png", class: "card-icon"
-                %li
-                = image_tag "icon/logo_mastercard.png", class: "card-icon"
-                %li
-                = image_tag "icon/logo_saison.png", class: "card-icon"
-                %li
-                = image_tag "icon/logo_jcb.png", class: "card-icon"
-                %li
-                = image_tag "icon/logo_amex.png", class: "card-icon"
-                %li
-                = image_tag "icon/logo_diners.png", class: "card-icon"
-                %li
-                = image_tag "icon/logo_discover.png", class: "card-icon"
+  = render 'layouts/header_simple'
+  .main-form
+    = form_tag(pay_cards_path, method: :post, id: 'charge-form',  name: "inputForm") do
+      %h2.main-form__title クレジットカード情報
+      %p.no-registration
+        = link_to "後で登録する", root_path
+      .main-form__wrapper
+        .main-contents
+          .contents-field--first
+            = label_tag "number", "カード番号", class: 'label'
+            %span.contents-field__require 必須
+            = text_field_tag "number", "4242424242424242", class: 'contents-field__input', placeholder: '半角数字のみ', maxlength: "16"
+            %ul.card-logo
+              %li
+              = image_tag "icon/logo_visa.png", class: "card-icon"
+              %li
+              = image_tag "icon/logo_mastercard.png", class: "card-icon"
+              %li
+              = image_tag "icon/logo_saison.png", class: "card-icon"
+              %li
+              = image_tag "icon/logo_jcb.png", class: "card-icon"
+              %li
+              = image_tag "icon/logo_amex.png", class: "card-icon"
+              %li
+              = image_tag "icon/logo_diners.png", class: "card-icon"
+              %li
+              = image_tag "icon/logo_discover.png", class: "card-icon"
 
 
-            .contents-field
-              = label_tag "card_expired", "有効期限", class: 'label'
-              %span.contents-field__require 必須
-              %br
-              .cards-expire__wrap
-                %select#exp_month{name: "exp_month", type: "text"}
-                  %option{value: ""} --
-                  %option{value: "1"}01
-                  %option{value: "2"}02
-                  %option{value: "3"}03
-                  %option{value: "4"}04
-                  %option{value: "5"}05
-                  %option{value: "6"}06
-                  %option{value: "7"}07
-                  %option{value: "8"}08
-                  %option{value: "9"}09
-                  %option{value: "10"}10
-                  %option{value: "11"}11
-                  %option{value: "12"}12
-                %span 月
-              .cards-expire__wrap
-                %select#exp_year{name: "exp_year", type: "text"}
-                  %option{value: ""} --
-                  %option{value: "2020"}20
-                  %option{value: "2021"}21
-                  %option{value: "2022"}22
-                  %option{value: "2023"}23
-                  %option{value: "2024"}24
-                  %option{value: "2025"}25
-                  %option{value: "2026"}26
-                  %option{value: "2027"}27
-                  %option{value: "2028"}28
-                  %option{value: "2029"}29
-                %span 年
-            .contents-field
-              = label_tag "security", "セキュリティコード", class: 'label'
-              %span.contents-field__require 必須
-              = number_field_tag "cvc","123", class: 'contents-field__input', placeholder: 'カード背面4桁もしくは3桁の番号', maxlength: "4"
-            #card_token
-              = submit_tag "追加する", id: "token_submit", class: 'default-btn'
-
-          
+          .contents-field
+            = label_tag "card_expired", "有効期限", class: 'label'
+            %span.contents-field__require 必須
+            %br
+            .cards-expire__wrap
+              %select#exp_month{name: "exp_month", type: "text"}
+                %option{value: ""} --
+                %option{value: "1"}01
+                %option{value: "2"}02
+                %option{value: "3"}03
+                %option{value: "4"}04
+                %option{value: "5"}05
+                %option{value: "6"}06
+                %option{value: "7"}07
+                %option{value: "8"}08
+                %option{value: "9"}09
+                %option{value: "10"}10
+                %option{value: "11"}11
+                %option{value: "12"}12
+              %span 月
+            .cards-expire__wrap
+              %select#exp_year{name: "exp_year", type: "text"}
+                %option{value: ""} --
+                %option{value: "2020"}20
+                %option{value: "2021"}21
+                %option{value: "2022"}22
+                %option{value: "2023"}23
+                %option{value: "2024"}24
+                %option{value: "2025"}25
+                %option{value: "2026"}26
+                %option{value: "2027"}27
+                %option{value: "2028"}28
+                %option{value: "2029"}29
+              %span 年
+          .contents-field
+            = label_tag "security", "セキュリティコード", class: 'label'
+            %span.contents-field__require 必須
+            = number_field_tag "cvc","123", class: 'contents-field__input', placeholder: 'カード背面4桁もしくは3桁の番号', maxlength: "4"
+          #card_token
+            = submit_tag "追加する", id: "token_submit", class: 'default-btn'
+  = render 'layouts/footer_simple'

--- a/app/views/cards/show.html.haml
+++ b/app/views/cards/show.html.haml
@@ -1,18 +1,20 @@
-.content__title
-  お支払方法
-  %br
-  クレジットカード一覧
-  %br
-  = "**** **** **** " + @card_information.last4
-  %br
-  - exp_month = @card_information.exp_month.to_s
-  - exp_year = @card_information.exp_year.to_s.slice(2,3)
-  = exp_month + " / " + exp_year
-  = form_tag(delete_cards_path, method: :post, id: 'charge-form',  name: "inputForm") do
-    %input{ type: "hidden", name: "card_id", value: "" }
-    %button.delete__button 削除する
-  %br
-  支払い方法について
-  %br
-  %br
+%body
+  = render 'layouts/header_simple'
+  .main-form
+    %h2.main-form__title
+      お支払方法
+    .main-form__wrapper
+      .main-contents
+        .credit-information__text
+          クレジットカード情報
+        .credit-information__number
+          = "**** **** **** " + @card_information.last4
+        .credit-information__date
+          - exp_month = @card_information.exp_month.to_s
+          - exp_year = @card_information.exp_year.to_s.slice(2,3)
+          = exp_month + " / " + exp_year
+        = form_tag(delete_cards_path, method: :post, class: 'btn-wrapper',  name: "inputForm") do
+          %input{ type: "hidden", name: "card_id", value: "" }
+          = submit_tag "削除する", class: 'delete-btn'
     = link_to "トップページへ戻る", root_path
+  = render 'layouts/footer_simple'

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,5 +1,5 @@
 %body
-  %header
+  = render 'layouts/header_simple'
   %main
     .main-form
       = form_for @user, url: user_registration_path do |f|
@@ -49,4 +49,4 @@
             .verification-wrapper
               %p.verification-wrapper__text「次へ進む」のボタンを押すことにより、利用規約に同意したものとみなします。
               =f.submit "次へ進む", class:'default-btn'
-  %footer
+  = render 'layouts/footer_simple'

--- a/app/views/devise/registrations/new_sending_destination.html.haml
+++ b/app/views/devise/registrations/new_sending_destination.html.haml
@@ -1,5 +1,5 @@
 %body
-  %header
+  = render 'layouts/header_simple'
   %main
     .main-form
       = form_for @sending_destination do |f|
@@ -46,3 +46,4 @@
               %span.contents-field__any 任意
               = f.text_field :phone_number, class:"contents-field__input", placeholder:"例）22233334444"
               =f.submit "次へ進む", class:'default-btn'
+  = render 'layouts/footer_simple'

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,27 +1,29 @@
 %body
-  %header
-  %main
-    .signin-form
-      .signin-form__no-account
-        %p.no-account-text アカウントをお持ちでない方はこちら
-        .default-btn.default-btn--no-account
-          = link_to "新規会員登録", new_user_registration_path
-      .main-form__login-form
-        .contents-field
-          .default-btn.default-btn--facebook(href='')
-            = link_to "Facebookで登録する", (href='')
-            = icon('fab', 'facebook-square', class: 'icon-facebook')
-        .contents-field
-          .default-btn.default-btn--google(href='')
-            = link_to "Googleで登録する", (href='')
-            = icon('fab', 'google', class: 'icon-google')
+  = render 'layouts/header_simple'
 
-      .main-contents
-        = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
-          .contents-field
-            = f.email_field :email, class:"contents-field__input",autofocus: true, autocomplete: "email"
-          .contents-field
-            = f.password_field :password, class:"contents-field__input",autocomplete: "current-password"
+  .signin-form
+    .signin-form__no-account
+      %p.no-account-text アカウントをお持ちでない方はこちら
+      .default-btn.default-btn--no-account
+        = link_to "新規会員登録", new_user_registration_path
+    .main-form__login-form
+      .contents-field
+        .default-btn.default-btn--facebook(href='')
+          = link_to "Facebookで登録する", (href='')
+          = icon('fab', 'facebook-square', class: 'icon-facebook')
+      .contents-field
+        .default-btn.default-btn--google(href='')
+          = link_to "Googleで登録する", (href='')
+          = icon('fab', 'google', class: 'icon-google')
 
-            = f.submit "ログイン", class: 'default-btn'
-  %footer
+    .main-contents
+      = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+        .contents-field
+          = f.label :メールアドレス
+          = f.email_field :email, class:"contents-field__input",autofocus: true, autocomplete: "email"
+        .contents-field
+          = f.label :パスワード
+          = f.password_field :password, class:"contents-field__input",autocomplete: "current-password"
+
+          = f.submit "ログイン", class: 'default-btn'
+  = render 'layouts/footer_simple'

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -29,8 +29,7 @@
           やることリスト
         .mypage
           = icon('far', 'smile-wink')
-          マイページ
-        = link_to "ログアウト", destroy_user_session_path, method: :delete #マイページ完成後移動
+          = link_to "マイページ", mypage_index_path
       -else
         = link_to "新規登録", signup_index_path
         = link_to "ログイン", new_user_session_path

--- a/app/views/mypage/_mypage_home.html.haml
+++ b/app/views/mypage/_mypage_home.html.haml
@@ -1,6 +1,5 @@
 
-= link_to '出品ボタン', new_item_path
-
 -# クレジットカード登録機能用（仮ボタン）
 -if user_signed_in?
   = link_to 'クレジットカード登録', new_card_path
+  = link_to "ログアウト", destroy_user_session_path, method: :delete #マイページ完成後移動

--- a/app/views/mypage/index.html.haml
+++ b/app/views/mypage/index.html.haml
@@ -7,4 +7,3 @@
   = render 'layouts/footer'
   //仮のボタン
   = render partial: 'shared/exhibition'
-    

--- a/app/views/signup/index.html.haml
+++ b/app/views/signup/index.html.haml
@@ -1,5 +1,5 @@
 %body
-  %header
+  = render 'layouts/header_simple'
   %main
     .main-form
       %h2.main-form__title 新規会員登録
@@ -19,4 +19,4 @@
               = link_to "Googleで登録する", (href='')
               = icon('fab', 'google', class: 'icon-google')
 
-  %footer
+  = render 'layouts/footer_simple'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
 
   root 'toppage#index'
   resources :toppage, only: [:index, :show]
+  resources :mypage, only: [:index]
 
   
   resources :items


### PR DESCRIPTION
# 修正内容
- 新規登録、ログイン、クレジットカード登録ページにフッター、ヘッターを追加
- ログインページのメールアドレス、パスワード入力項目がわかるようにラベルの追加
- 新規登録の住所等入力ページの後にクレジットカード登録ページを追加

# 今後の実装
- 商品購入時クレジットカードが未登録の場合はクレジットカード登録ページへ飛ぶ。商品購入機能実装後に修正
- マイページにクレジットカード登録ボタンを仮置きしている。マイページ完成後に移動する。

# 登録画面
https://gyazo.com/6f438a140aee0461244f3e8800a3bb93
https://gyazo.com/e7466ade6b7dbf83ab8bb1098fa09e83


