### PR TITLE
商品出品ページのパス先修正とパンくずリスト修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -30,7 +30,7 @@ class ItemsController < ApplicationController
     @item = Item.new(item_params)
     @item.build_brand(name: params[:item][:brand][:name])
     if @item.save
-      redirect_to :root
+      redirect_to item_path(@item)
       flash[:success] = "商品出品が完了しました"
     else
       render :new
@@ -41,7 +41,7 @@ class ItemsController < ApplicationController
   def update
     @item.build_brand(name: params[:item][:brand][:name])
     if @item.update(item_params)
-      redirect_to :root
+      redirect_to item_path(@item)
       flash[:success] = "商品情報を更新しました"
     else
       render :edit
@@ -114,7 +114,7 @@ class ItemsController < ApplicationController
   end
 
   def item_params
-    params.permit(
+    params.require(:item).permit(
       :name,
       :item_condition_id,
       :introduction,

--- a/app/views/mypage/cards/show.html.haml
+++ b/app/views/mypage/cards/show.html.haml
@@ -1,4 +1,8 @@
 = render 'layouts/header'
+-# パンくずリスト
+.breadcrumbs_list
+  - breadcrumb :mypage_cards_show
+  = breadcrumbs separator: " &rsaquo; "
 .mypage-wrap
   = render 'mypage/side_menu'
   .main_menu

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -32,6 +32,12 @@ crumb :mypage_cards_new do
   parent :mypage_cards_index
 end
 
+# クレジットカード情報登録後の表示
+crumb :mypage_cards_show do
+  link 'クレジットカード情報', mypage_cards_show_path
+  parent :mypage_cards_index
+end
+
 # ログアウト
 crumb :mypage_logout do
   link 'ログアウト', logout_mypage_index_path


### PR DESCRIPTION
# What
- 出品完了後の遷移先を商品詳細ページに変更
- 出品編集完了後の遷移先を商品詳細ページに変更
- クレジットカード情報表示ページにパンくずリストを追加