### PR TITLE
お気に入りのカウント数表示

### DIFF
--- a/app/views/items/_item.html.haml
+++ b/app/views/items/_item.html.haml
@@ -10,7 +10,6 @@
           %li.price= "¥ #{item.price.to_s(:delimited)}"
           %li.icon
             %i.fa.fa-star
-              0
-              -# いいね数のカウントは未実装
+              = item.favorites.length
         %p
           (税込)


### PR DESCRIPTION
# What
トップページ商品一覧に商品ごとのお気に入り数を表示

# Why
商品詳細画面でお気に入りされたカウントを一覧でも見れるようにするため