### PR TITLE
gem バージョン指定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem 'jbuilder', '~> 2.5'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri
-  gem 'capistrano'
+  gem 'capistrano', '3.12.0'
   gem 'capistrano-rbenv'
   gem 'capistrano-bundler'
   gem 'capistrano-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,8 +52,8 @@ GEM
     bcrypt (3.1.13)
     bindex (0.8.1)
     builder (3.2.4)
-    byebug (11.1.1)
-    capistrano (3.13.0)
+    byebug (11.1.2)
+    capistrano (3.12.0)
       airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
@@ -238,7 +238,7 @@ GEM
       rest-client (~> 2.0)
     polyamorous (2.3.0)
       activerecord (>= 5.0)
-    pry (0.13.0)
+    pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
     pry-rails (0.3.9)
@@ -328,7 +328,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sassc (2.2.1)
+    sassc (2.3.0)
       ffi (~> 1.9)
     sexp_processor (4.14.1)
     spring (2.1.0)
@@ -378,7 +378,7 @@ DEPENDENCIES
   ancestry
   antivirus
   byebug
-  capistrano
+  capistrano (= 3.12.0)
   capistrano-bundler
   capistrano-rails
   capistrano-rbenv


### PR DESCRIPTION
# What
gem 'capistrano', '3.12.0'
に指定
# Why
指定しておらずバージョンエラーが起こってしまったため